### PR TITLE
CSS for Code of Conduct Page

### DIFF
--- a/coc.html
+++ b/coc.html
@@ -1,56 +1,161 @@
-<h1 id="code-of-conduct">Code of Conduct</h1>
-<p>NYC Code and Coffee is dedicated to providing a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of group participants in any form. Sexual language and imagery is not appropriate for any event or communication channel. Group participants violating these rules may be sanctioned or expelled from the event at the discretion of the organizers.</p>
-<p>Harassment includes, but is not limited to:</p>
-<ul>
-<li>Verbal comments that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or level of experience</li>
-<li>Sexual images in public spaces</li>
-<li>Deliberate intimidation, stalking, or following</li>
-<li>Harassing photography or recording</li>
-<li>Sustained disruption of discussion or other events</li>
-<li>Inappropriate physical contact</li>
-<li>Unwelcome sexual attention</li>
-<li>Advocating for, or encouraging, any of the above behaviour</li>
-</ul>
-<h2 id="enforcement">Enforcement</h2>
-<p>Participants asked to stop any harassing behavior are expected to comply immediately. If a participant engages in harassing behaviour, event organisers retain the right to take any actions to keep the event a welcoming environment for all participants. This includes warning the offender or expulsion from the event.</p>
-<p>We expect participants to follow these rules at all event venues and event-related social activities.</p>
-<h2 id="reporting">Reporting</h2>
-<p>If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible. Group organizers can be <a href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders">identified on Meetup</a>. Harassment and other code of conduct violations reduce the value of our event for everyone. We want you to be happy at our event. People like you make our event a better place.</p>
-<p>You can make a report either personally or anonymously.</p>
-<h3 id="anonymous-report">Anonymous Report</h3>
-<p>You can <a href="https://forms.gle/5pJDSdhBZx5ibCMk8">make an anonymous report</a>. We can&#39;t follow up an anonymous report with you directly, but we will fully investigate it and take whatever action is necessary to prevent a recurrence.</p>
-<h3 id="personal-report">Personal Report</h3>
-<p>You can make a personal report by:</p>
-<ul>
-<li><a href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders">Contacting a group organizer on Meetup</a>.</li>
-<li>Emailing organizer Steve Chen at <a href="mailto:stevechenweb@gmail.com?subject=URGENT:%20NYC%20Code%20and%20Coffee%20Code%20of%20Conduct%20violation">stevechenweb@gmail.com</a>.</li>
-</ul>
-<p>When taking a personal report, our organizers may involve other organizers to ensure your report is managed properly. This can be upsetting, but we&#39;ll handle it as respectfully as possible, and you can include someone to support you. You won&#39;t be asked to confront anyone and we won&#39;t tell anyone who you are.</p>
-<p>Our team will be happy to help you contact law enforcement, provide escorts, or otherwise assist you to feel safe for the duration of the event. We value your attendance.</p>
-<p>Contact a <a href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders">group organizer on Meetup</a>.</p>
-<h2 id="more-resources">More Resources</h2>
-<ul>
-<li><p>NYS Domestic Violence and Sexual Violence Hotline: 
-<a href="tel:8009426906">1-800-942-6906</a>
-Text 844-997-2121 or <a href="https://opdv.ny.gov/">Chat online</a></p>
-</li>
-<li><p>New York City: <a href="tel:8006214673">1-800-621-HOPE</a> (4673) or 311(tel:311)</p>
-</li>
-<li><p><a href="https://www1.nyc.gov/site/cchr/about/report-discrimination.page">Report discrimination online</a> to NYC Human Rights</p>
-</li>
-<li><p>NYS Bias and Discrimination Hotline: 1-888-392-3644</p>
-</li>
-</ul>
-<details>
-  <summary>Click for more</summary>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Code of Conduct</title>
+  </head>
+  <body>
+    <h1 id="code-of-conduct">Code of Conduct</h1>
+    <p>
+      NYC Code and Coffee is dedicated to providing a harassment-free experience
+      for everyone, regardless of level of experience, gender, gender identity
+      and expression, sexual orientation, disability, physical appearance, body
+      size, race, age, or religion. We do not tolerate harassment of group
+      participants in any form. Sexual language and imagery is not appropriate
+      for any event or communication channel. Group participants violating these
+      rules may be sanctioned or expelled from the event at the discretion of
+      the organizers.
+    </p>
+    <p>Harassment includes, but is not limited to:</p>
+    <ul>
+      <li>
+        Verbal comments that reinforce social structures of domination related
+        to gender, gender identity and expression, sexual orientation,
+        disability, physical appearance, body size, race, age, religion, or
+        level of experience
+      </li>
+      <li>Sexual images in public spaces</li>
+      <li>Deliberate intimidation, stalking, or following</li>
+      <li>Harassing photography or recording</li>
+      <li>Sustained disruption of discussion or other events</li>
+      <li>Inappropriate physical contact</li>
+      <li>Unwelcome sexual attention</li>
+      <li>Advocating for, or encouraging, any of the above behaviour</li>
+    </ul>
+    <h2 id="enforcement">Enforcement</h2>
+    <p>
+      Participants asked to stop any harassing behavior are expected to comply
+      immediately. If a participant engages in harassing behaviour, event
+      organisers retain the right to take any actions to keep the event a
+      welcoming environment for all participants. This includes warning the
+      offender or expulsion from the event.
+    </p>
+    <p>
+      We expect participants to follow these rules at all event venues and
+      event-related social activities.
+    </p>
+    <h2 id="reporting">Reporting</h2>
+    <p>
+      If someone makes you or anyone else feel unsafe or unwelcome, please
+      report it as soon as possible. Group organizers can be
+      <a href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
+        >identified on Meetup</a
+      >. Harassment and other code of conduct violations reduce the value of our
+      event for everyone. We want you to be happy at our event. People like you
+      make our event a better place.
+    </p>
+    <p>You can make a report either personally or anonymously.</p>
+    <h3 id="anonymous-report">Anonymous Report</h3>
+    <p>
+      You can
+      <a href="https://forms.gle/5pJDSdhBZx5ibCMk8">make an anonymous report</a
+      >. We can&#39;t follow up an anonymous report with you directly, but we
+      will fully investigate it and take whatever action is necessary to prevent
+      a recurrence.
+    </p>
+    <h3 id="personal-report">Personal Report</h3>
+    <p>You can make a personal report by:</p>
+    <ul>
+      <li>
+        <a
+          href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
+          >Contacting a group organizer on Meetup</a
+        >.
+      </li>
+      <li>
+        Emailing organizer Steve Chen at
+        <a
+          href="mailto:stevechenweb@gmail.com?subject=URGENT:%20NYC%20Code%20and%20Coffee%20Code%20of%20Conduct%20violation"
+          >stevechenweb@gmail.com</a
+        >.
+      </li>
+    </ul>
+    <p>
+      When taking a personal report, our organizers may involve other organizers
+      to ensure your report is managed properly. This can be upsetting, but
+      we&#39;ll handle it as respectfully as possible, and you can include
+      someone to support you. You won&#39;t be asked to confront anyone and we
+      won&#39;t tell anyone who you are.
+    </p>
+    <p>
+      Our team will be happy to help you contact law enforcement, provide
+      escorts, or otherwise assist you to feel safe for the duration of the
+      event. We value your attendance.
+    </p>
+    <p>
+      Contact a
+      <a href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
+        >group organizer on Meetup</a
+      >.
+    </p>
+    <h2 id="more-resources">More Resources</h2>
+    <ul>
+      <li>
+        <p>
+          NYS Domestic Violence and Sexual Violence Hotline:
+          <a href="tel:8009426906">1-800-942-6906</a>
+          Text 844-997-2121 or <a href="https://opdv.ny.gov/">Chat online</a>
+        </p>
+      </li>
+      <li>
+        <p>
+          New York City: <a href="tel:8006214673">1-800-621-HOPE</a> (4673) or
+          311(tel:311)
+        </p>
+      </li>
+      <li>
+        <p>
+          <a
+            href="https://www1.nyc.gov/site/cchr/about/report-discrimination.page"
+            >Report discrimination online</a
+          >
+          to NYC Human Rights
+        </p>
+      </li>
+      <li><p>NYS Bias and Discrimination Hotline: 1-888-392-3644</p></li>
+    </ul>
+    <details>
+      <summary>Click for more</summary>
 
-- <a href="https://www.nyscasa.org/get-help/find-your-local-rape-crisis-program/">NYS Rape Crisis Centers</a>
-- <a href="https://www.health.ny.gov/prevention/sexual_violence/">NYS DOH Sexual Violence Prevention Program</a>
-- <a href="https://ovs.ny.gov/locate-program">NY Crime Victim Assistance Programs</a>
-- <a href="https://1in6.org/">1 in 6 (for male survivors of sexual abuse or assault)</a>
-- <a href="https://translifeline.org/">Trans Lifeline</a>: 1-877-565-8860
+      -
+      <a
+        href="https://www.nyscasa.org/get-help/find-your-local-rape-crisis-program/"
+        >NYS Rape Crisis Centers</a
+      >
+      -
+      <a href="https://www.health.ny.gov/prevention/sexual_violence/"
+        >NYS DOH Sexual Violence Prevention Program</a
+      >
+      -
+      <a href="https://ovs.ny.gov/locate-program"
+        >NY Crime Victim Assistance Programs</a
+      >
+      -
+      <a href="https://1in6.org/"
+        >1 in 6 (for male survivors of sexual abuse or assault)</a
+      >
+      - <a href="https://translifeline.org/">Trans Lifeline</a>: 1-877-565-8860
+    </details>
 
-</details>
-
-<h2 id="attribution">Attribution</h2>
-<p>This Code of Conduct is adapted from <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">the Geek Feminism conference anti-harassment policy</a>.</p>
+    <h2 id="attribution">Attribution</h2>
+    <p>
+      This Code of Conduct is adapted from
+      <a
+        href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy"
+        >the Geek Feminism conference anti-harassment policy</a
+      >.
+    </p>
+  </body>
+</html>

--- a/coc.html
+++ b/coc.html
@@ -5,157 +5,167 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Code of Conduct</title>
+    <link rel="stylesheet" href="assets/css/main.css" />
   </head>
   <body>
-    <h1 id="code-of-conduct">Code of Conduct</h1>
-    <p>
-      NYC Code and Coffee is dedicated to providing a harassment-free experience
-      for everyone, regardless of level of experience, gender, gender identity
-      and expression, sexual orientation, disability, physical appearance, body
-      size, race, age, or religion. We do not tolerate harassment of group
-      participants in any form. Sexual language and imagery is not appropriate
-      for any event or communication channel. Group participants violating these
-      rules may be sanctioned or expelled from the event at the discretion of
-      the organizers.
-    </p>
-    <p>Harassment includes, but is not limited to:</p>
-    <ul>
-      <li>
-        Verbal comments that reinforce social structures of domination related
-        to gender, gender identity and expression, sexual orientation,
-        disability, physical appearance, body size, race, age, religion, or
-        level of experience
-      </li>
-      <li>Sexual images in public spaces</li>
-      <li>Deliberate intimidation, stalking, or following</li>
-      <li>Harassing photography or recording</li>
-      <li>Sustained disruption of discussion or other events</li>
-      <li>Inappropriate physical contact</li>
-      <li>Unwelcome sexual attention</li>
-      <li>Advocating for, or encouraging, any of the above behaviour</li>
-    </ul>
-    <h2 id="enforcement">Enforcement</h2>
-    <p>
-      Participants asked to stop any harassing behavior are expected to comply
-      immediately. If a participant engages in harassing behaviour, event
-      organisers retain the right to take any actions to keep the event a
-      welcoming environment for all participants. This includes warning the
-      offender or expulsion from the event.
-    </p>
-    <p>
-      We expect participants to follow these rules at all event venues and
-      event-related social activities.
-    </p>
-    <h2 id="reporting">Reporting</h2>
-    <p>
-      If someone makes you or anyone else feel unsafe or unwelcome, please
-      report it as soon as possible. Group organizers can be
-      <a href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
-        >identified on Meetup</a
-      >. Harassment and other code of conduct violations reduce the value of our
-      event for everyone. We want you to be happy at our event. People like you
-      make our event a better place.
-    </p>
-    <p>You can make a report either personally or anonymously.</p>
-    <h3 id="anonymous-report">Anonymous Report</h3>
-    <p>
-      You can
-      <a href="https://forms.gle/5pJDSdhBZx5ibCMk8">make an anonymous report</a
-      >. We can&#39;t follow up an anonymous report with you directly, but we
-      will fully investigate it and take whatever action is necessary to prevent
-      a recurrence.
-    </p>
-    <h3 id="personal-report">Personal Report</h3>
-    <p>You can make a personal report by:</p>
-    <ul>
-      <li>
-        <a
-          href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
-          >Contacting a group organizer on Meetup</a
-        >.
-      </li>
-      <li>
-        Emailing organizer Steve Chen at
-        <a
-          href="mailto:stevechenweb@gmail.com?subject=URGENT:%20NYC%20Code%20and%20Coffee%20Code%20of%20Conduct%20violation"
-          >stevechenweb@gmail.com</a
-        >.
-      </li>
-    </ul>
-    <p>
-      When taking a personal report, our organizers may involve other organizers
-      to ensure your report is managed properly. This can be upsetting, but
-      we&#39;ll handle it as respectfully as possible, and you can include
-      someone to support you. You won&#39;t be asked to confront anyone and we
-      won&#39;t tell anyone who you are.
-    </p>
-    <p>
-      Our team will be happy to help you contact law enforcement, provide
-      escorts, or otherwise assist you to feel safe for the duration of the
-      event. We value your attendance.
-    </p>
-    <p>
-      Contact a
-      <a href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
-        >group organizer on Meetup</a
-      >.
-    </p>
-    <h2 id="more-resources">More Resources</h2>
-    <ul>
-      <li>
+    <section>
+      <div class="inner">
+        <h1 id="code-of-conduct">Code of Conduct</h1>
         <p>
-          NYS Domestic Violence and Sexual Violence Hotline:
-          <a href="tel:8009426906">1-800-942-6906</a>
-          Text 844-997-2121 or <a href="https://opdv.ny.gov/">Chat online</a>
+          NYC Code and Coffee is dedicated to providing a harassment-free
+          experience for everyone, regardless of level of experience, gender,
+          gender identity and expression, sexual orientation, disability,
+          physical appearance, body size, race, age, or religion. We do not
+          tolerate harassment of group participants in any form. Sexual language
+          and imagery is not appropriate for any event or communication channel.
+          Group participants violating these rules may be sanctioned or expelled
+          from the event at the discretion of the organizers.
         </p>
-      </li>
-      <li>
+        <p>Harassment includes, but is not limited to:</p>
+        <ul>
+          <li>
+            Verbal comments that reinforce social structures of domination
+            related to gender, gender identity and expression, sexual
+            orientation, disability, physical appearance, body size, race, age,
+            religion, or level of experience
+          </li>
+          <li>Sexual images in public spaces</li>
+          <li>Deliberate intimidation, stalking, or following</li>
+          <li>Harassing photography or recording</li>
+          <li>Sustained disruption of discussion or other events</li>
+          <li>Inappropriate physical contact</li>
+          <li>Unwelcome sexual attention</li>
+          <li>Advocating for, or encouraging, any of the above behaviour</li>
+        </ul>
+        <h2 id="enforcement">Enforcement</h2>
         <p>
-          New York City: <a href="tel:8006214673">1-800-621-HOPE</a> (4673) or
-          311(tel:311)
+          Participants asked to stop any harassing behavior are expected to
+          comply immediately. If a participant engages in harassing behaviour,
+          event organisers retain the right to take any actions to keep the
+          event a welcoming environment for all participants. This includes
+          warning the offender or expulsion from the event.
         </p>
-      </li>
-      <li>
         <p>
+          We expect participants to follow these rules at all event venues and
+          event-related social activities.
+        </p>
+        <h2 id="reporting">Reporting</h2>
+        <p>
+          If someone makes you or anyone else feel unsafe or unwelcome, please
+          report it as soon as possible. Group organizers can be
           <a
-            href="https://www1.nyc.gov/site/cchr/about/report-discrimination.page"
-            >Report discrimination online</a
-          >
-          to NYC Human Rights
+            href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
+            >identified on Meetup</a
+          >. Harassment and other code of conduct violations reduce the value of
+          our event for everyone. We want you to be happy at our event. People
+          like you make our event a better place.
         </p>
-      </li>
-      <li><p>NYS Bias and Discrimination Hotline: 1-888-392-3644</p></li>
-    </ul>
-    <details>
-      <summary>Click for more</summary>
+        <p>You can make a report either personally or anonymously.</p>
+        <h2 id="anonymous-report">Anonymous Report</h2>
+        <p>
+          You can
+          <a href="https://forms.gle/5pJDSdhBZx5ibCMk8"
+            >make an anonymous report</a
+          >. We can&#39;t follow up an anonymous report with you directly, but
+          we will fully investigate it and take whatever action is necessary to
+          prevent a recurrence.
+        </p>
+        <h2 id="personal-report">Personal Report</h2>
+        <p>You can make a personal report by:</p>
+        <ul>
+          <li>
+            <a
+              href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
+              >Contacting a group organizer on Meetup</a
+            >.
+          </li>
+          <li>
+            Emailing organizer Steve Chen at
+            <a
+              href="mailto:stevechenweb@gmail.com?subject=URGENT:%20NYC%20Code%20and%20Coffee%20Code%20of%20Conduct%20violation"
+              >stevechenweb@gmail.com</a
+            >.
+          </li>
+        </ul>
+        <p>
+          When taking a personal report, our organizers may involve other
+          organizers to ensure your report is managed properly. This can be
+          upsetting, but we&#39;ll handle it as respectfully as possible, and
+          you can include someone to support you. You won&#39;t be asked to
+          confront anyone and we won&#39;t tell anyone who you are.
+        </p>
+        <p>
+          Our team will be happy to help you contact law enforcement, provide
+          escorts, or otherwise assist you to feel safe for the duration of the
+          event. We value your attendance.
+        </p>
+        <p>
+          Contact a
+          <a
+            href="https://www.meetup.com/new-york-code-coffee/members/?op=leaders"
+            >group organizer on Meetup</a
+          >.
+        </p>
+        <h2 id="more-resources">More Resources</h2>
+        <ul>
+          <li>
+            <p>
+              NYS Domestic Violence and Sexual Violence Hotline:
+              <a href="tel:8009426906">1-800-942-6906</a>
+              Text 844-997-2121 or
+              <a href="https://opdv.ny.gov/">Chat online</a>
+            </p>
+          </li>
+          <li>
+            <p>
+              New York City: <a href="tel:8006214673">1-800-621-HOPE</a> (4673)
+              or 311(tel:311)
+            </p>
+          </li>
+          <li>
+            <p>
+              <a
+                href="https://www1.nyc.gov/site/cchr/about/report-discrimination.page"
+                >Report discrimination online</a
+              >
+              to NYC Human Rights
+            </p>
+          </li>
+          <li><p>NYS Bias and Discrimination Hotline: 1-888-392-3644</p></li>
+        </ul>
+        <details>
+          <summary>Click for more</summary>
 
-      -
-      <a
-        href="https://www.nyscasa.org/get-help/find-your-local-rape-crisis-program/"
-        >NYS Rape Crisis Centers</a
-      >
-      -
-      <a href="https://www.health.ny.gov/prevention/sexual_violence/"
-        >NYS DOH Sexual Violence Prevention Program</a
-      >
-      -
-      <a href="https://ovs.ny.gov/locate-program"
-        >NY Crime Victim Assistance Programs</a
-      >
-      -
-      <a href="https://1in6.org/"
-        >1 in 6 (for male survivors of sexual abuse or assault)</a
-      >
-      - <a href="https://translifeline.org/">Trans Lifeline</a>: 1-877-565-8860
-    </details>
+          -
+          <a
+            href="https://www.nyscasa.org/get-help/find-your-local-rape-crisis-program/"
+            >NYS Rape Crisis Centers</a
+          >
+          -
+          <a href="https://www.health.ny.gov/prevention/sexual_violence/"
+            >NYS DOH Sexual Violence Prevention Program</a
+          >
+          -
+          <a href="https://ovs.ny.gov/locate-program"
+            >NY Crime Victim Assistance Programs</a
+          >
+          -
+          <a href="https://1in6.org/"
+            >1 in 6 (for male survivors of sexual abuse or assault)</a
+          >
+          - <a href="https://translifeline.org/">Trans Lifeline</a>:
+          1-877-565-8860
+        </details>
 
-    <h2 id="attribution">Attribution</h2>
-    <p>
-      This Code of Conduct is adapted from
-      <a
-        href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy"
-        >the Geek Feminism conference anti-harassment policy</a
-      >.
-    </p>
+        <h2 id="attribution">Attribution</h2>
+        <p>
+          This Code of Conduct is adapted from
+          <a
+            href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy"
+            >the Geek Feminism conference anti-harassment policy</a
+          >.
+        </p>
+      </div>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
- Added `<!DOCTYPE html>` declaration

- Implemented the design from the main page to the code of conduct page by linking the main.css to coc.html. Additionally, I added a few tags to give the page width and max-width attributes. 

![codeofconduct2](https://user-images.githubusercontent.com/34969423/205481516-1a26fdf2-1238-483d-8815-ec4f4f49cf8b.png)
